### PR TITLE
Enable paging intercept on servlet only

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>1.5.9.RELEASE</version>
+    <version>2.0.6.RELEASE</version>
     <relativePath /> <!-- lookup parent from repository -->
   </parent>
 

--- a/src/main/java/com/blibli/oss/common/CommonServletAutoConfigurer.java
+++ b/src/main/java/com/blibli/oss/common/CommonServletAutoConfigurer.java
@@ -3,9 +3,11 @@ package com.blibli.oss.common;
 import com.blibli.oss.common.paging.PagingInterceptor;
 import com.blibli.oss.common.properties.PagingProperties;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter;
 
 /**
@@ -13,7 +15,8 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter
  */
 @Configuration
 @EnableConfigurationProperties({PagingProperties.class})
-public class CommonAutoConfigurer extends WebMvcConfigurerAdapter {
+@ConditionalOnWebApplication(type = ConditionalOnWebApplication.Type.SERVLET)
+public class CommonServletAutoConfigurer implements WebMvcConfigurer {
 
   @Autowired
   private PagingProperties pagingProperties;

--- a/src/main/java/com/blibli/oss/common/paging/Paging.java
+++ b/src/main/java/com/blibli/oss/common/paging/Paging.java
@@ -11,8 +11,8 @@ import java.util.List;
 /**
  * @author Eko Kurniawan Khannedy
  */
-@Data
 @NoArgsConstructor
+@Data
 @AllArgsConstructor
 @Builder
 public class Paging {

--- a/src/main/resources/META-INF/spring.factories
+++ b/src/main/resources/META-INF/spring.factories
@@ -1,2 +1,2 @@
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-com.blibli.oss.common.CommonAutoConfigurer
+com.blibli.oss.common.CommonServletAutoConfigurer

--- a/src/test/java/com/blibli/oss/common/TestApplication.java
+++ b/src/test/java/com/blibli/oss/common/TestApplication.java
@@ -7,6 +7,6 @@ import org.springframework.context.annotation.Import;
  * @author Eko Kurniawan Khannedy
  */
 @SpringBootApplication
-@Import(CommonAutoConfigurer.class)
+@Import(CommonServletAutoConfigurer.class)
 public class TestApplication {
 }


### PR DESCRIPTION
Make common-plugin compatible with spring-boot v2.x.

This make the `CommonAutoConfigurer` configuration bean to only active when the application running in `SERVLET` mode.